### PR TITLE
Forcefully update some key MirrorBrain indexes after mirroring

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -36,3 +36,20 @@ ssh $HOST "sh trigger-hudson"
 
 echo ">> move index from staging to production"
 ssh www-data@localhost "cd /var/www; rsync -avz pkg.jenkins-ci.org.staging/ pkg.jenkins-ci.org/"
+
+# This section of the script aims to ensure that at least one of our primary mirrors has the
+# "big" archives before we complete execution. This will help prevent users from unexpectedly
+# hitting fallback mirrors when our primary mirrors *have* the data and we simply haven't updated
+# our indexes
+#
+# https://issues.jenkins-ci.org/browse/INFRA-483
+echo ">> Sleeping to allow the OSUOSL to propogate some bits"
+sleep 120
+
+echo ">> attempting to update indexes with released archive"
+for f in debian debian-stable redhat redhat-stable war war-stable opensuse opensuse-stable osx osx-stable windows windows-stable; do
+  echo ">>>> updating index for ${f}/"
+  mb scan -j 2 -v -d $f -e ftp-chi.osuosl.org;
+done
+
+


### PR DESCRIPTION
This should help ensure users don't unintentionally hit the fallback mirror when we have a new release

References INFRA-483
